### PR TITLE
support for weekly stats starting on mondays #16

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,7 @@ Settings
   metrics (default is 'daily')
 * ``REDIS_METRICS_MAX_GRANULARITY`` - The maximum-time granularity for your
   metrics (default is 'yearly')
+* ``REDIS_METRICS_MONDAY_FIRST_DAY_OF_WEEK`` - set to True if week should start on monday, defaults to False
 
 .. _usage:
 

--- a/redis_metrics/settings.py
+++ b/redis_metrics/settings.py
@@ -29,6 +29,7 @@ class AppSettings(object):
         'REDIS_METRICS_SOCKET_CONNECTION_POOL': None,
         'REDIS_METRICS_MIN_GRANULARITY': 'daily',
         'REDIS_METRICS_MAX_GRANULARITY': 'yearly',
+        'REDIS_METRICS_MONDAY_FIRST_DAY_OF_WEEK': False,
     }
 
     def __getattr__(self, name):
@@ -49,15 +50,3 @@ app_settings = AppSettings()
 
 # All possible granularity values.
 GRANULARITIES = ['seconds', 'minutes', 'hourly', 'daily', 'weekly', 'monthly', 'yearly']
-
-
-# The Redis metric key and date formatting patterns for each key, by granularity
-METRIC_KEY_PATTERNS = {
-    "seconds": {"key": "m:{0}:s:{1}", "date_format": "%Y-%m-%d-%H-%M-%S"},
-    "minutes": {"key": "m:{0}:i:{1}", "date_format": "%Y-%m-%d-%H-%M"},
-    "hourly": {"key": "m:{0}:h:{1}", "date_format": "%Y-%m-%d-%H"},
-    "daily": {"key": "m:{0}:{1}", "date_format": "%Y-%m-%d"},
-    "weekly": {"key": "m:{0}:w:{1}", "date_format": "%Y-%U"},
-    "monthly": {"key": "m:{0}:m:{1}", "date_format": "%Y-%m"},
-    "yearly": {"key": "m:{0}:y:{1}", "date_format": "%Y"},
-}

--- a/redis_metrics/tests/test_settings.py
+++ b/redis_metrics/tests/test_settings.py
@@ -12,6 +12,7 @@ from .. import settings as rs
 @override_settings(REDIS_METRICS_SOCKET_CONNECTION_POOL=None)
 @override_settings(REDIS_METRICS_MIN_GRANULARITY='seconds')
 @override_settings(REDIS_METRICS_MAX_GRANULARITY='yearly')
+@override_settings(REDIS_METRICS_MONDAY_FIRST_DAY_OF_WEEK=False)
 class TestAppSettings(TestCase):
 
     def test_settings_getattr(self):
@@ -23,6 +24,7 @@ class TestAppSettings(TestCase):
         self.assertEquals(rs.app_settings.REDIS_METRICS_SOCKET_CONNECTION_POOL, None)
         self.assertEquals(rs.app_settings.REDIS_METRICS_MIN_GRANULARITY, 'seconds')
         self.assertEquals(rs.app_settings.REDIS_METRICS_MAX_GRANULARITY, 'yearly')
+        self.assertEquals(rs.app_settings.REDIS_METRICS_MONDAY_FIRST_DAY_OF_WEEK, False)
 
     def test_settings_getitem(self):
         self.assertEquals(rs.app_settings['REDIS_METRICS_HOST'], 'localhost')
@@ -33,17 +35,11 @@ class TestAppSettings(TestCase):
         self.assertEquals(rs.app_settings['REDIS_METRICS_SOCKET_CONNECTION_POOL'], None)
         self.assertEquals(rs.app_settings['REDIS_METRICS_MIN_GRANULARITY'], 'seconds')
         self.assertEquals(rs.app_settings['REDIS_METRICS_MAX_GRANULARITY'], 'yearly')
+        self.assertEquals(rs.app_settings['REDIS_METRICS_MONDAY_FIRST_DAY_OF_WEEK'], False)
 
     def test_settings_getattr_raises_attribute_error(self):
         with self.assertRaises(AttributeError):
             rs.app_settings.REDIS_METRICS_LOLWUT
-
-    def test_metric_key_patterns(self):
-        # These two things should always be the same.
-        self.assertEqual(
-            sorted(rs.METRIC_KEY_PATTERNS.keys()),
-            sorted(rs.GRANULARITIES)
-        )
 
     def test__test_granularities_constant(self):
         # Smoke test to catch myself when this changes.


### PR DESCRIPTION
I had to refactor METRIC_KEY_PATTERNS dict into function, because of the previous import time build of the  dict, there is dynamic part now.
