### PR TITLE
Allow importing of historical data

### DIFF
--- a/redis_metrics/models.py
+++ b/redis_metrics/models.py
@@ -246,7 +246,7 @@ class R(object):
         # Finally, remove the slug from the set
         self.r.srem(self._metric_slugs_key, slug)
 
-    def set_metric(self, slug, value, category=None, expire=None):
+    def set_metric(self, slug, value, category=None, expire=None, date=None):
         """Assigns a specific value to the *current* metric. You can use this
         to start a metric at a value greater than 0 or to reset a metric.
 
@@ -261,6 +261,8 @@ class R(object):
         * ``category`` -- (optional) Assign the metric to a Category (a string)
         * ``expire`` -- (optional) Specify the number of seconds in which the
           metric will expire.
+        * ``date`` -- (optional) Specify the timestamp for the metric; default
+          used to build the keys will be the current date and time in UTC form.
 
         Redis keys for each metric (slug) take the form:
 
@@ -273,7 +275,7 @@ class R(object):
             m:<slug>:y:<yyyy>                # Year
 
         """
-        keys = self._build_keys(slug)
+        keys = self._build_keys(slug, date=date)
 
         # Add the slug to the set of metric slugs
         self.r.sadd(self._metric_slugs_key, slug)
@@ -293,7 +295,7 @@ class R(object):
             for k in keys:
                 self.r.expire(k, expire)
 
-    def metric(self, slug, num=1, category=None, expire=None):
+    def metric(self, slug, num=1, category=None, expire=None, date=None):
         """Records a metric, creating it if it doesn't exist or incrementing it
         if it does. All metrics are prefixed with 'm', and automatically
         aggregate for Seconds, Minutes, Hours, Day, Week, Month, and Year.
@@ -306,6 +308,8 @@ class R(object):
         * ``category`` -- (optional) Assign the metric to a Category (a string)
         * ``expire`` -- (optional) Specify the number of seconds in which the
           metric will expire.
+        * ``date`` -- (optional) Specify the timestamp for the metric; default
+          used to build the keys will be the current date and time in UTC form.
 
         Redis keys for each metric (slug) take the form:
 
@@ -326,7 +330,7 @@ class R(object):
 
         # Increment keys. NOTE: current redis-py (2.7.2) doesn't include an
         # incrby method; .incr accepts a second ``amount`` parameter.
-        keys = self._build_keys(slug)
+        keys = self._build_keys(slug, date=date)
 
         # Use a pipeline to speed up incrementing multiple keys
         pipe = self.r.pipeline()

--- a/redis_metrics/tests/test_utils.py
+++ b/redis_metrics/tests/test_utils.py
@@ -51,7 +51,7 @@ class TestUtils(TestCase):
             utils.set_metric("test-slug", 42)
             mock_get_r.assert_has_calls([
                 call(),
-                call().set_metric("test-slug", 42, category=None, expire=None),
+                call().set_metric("test-slug", 42, category=None, expire=None, date=None),
             ])
 
     def test_set_metric_with_category(self):
@@ -59,7 +59,7 @@ class TestUtils(TestCase):
             utils.set_metric("test-slug", 42, category="Woo")
             mock_get_r.assert_has_calls([
                 call(),
-                call().set_metric("test-slug", 42, category="Woo", expire=None),
+                call().set_metric("test-slug", 42, category="Woo", expire=None, date=None),
             ])
 
     def test_set_metric_with_expiration(self):
@@ -67,7 +67,7 @@ class TestUtils(TestCase):
             utils.set_metric("test-slug", 42, expire=300)
             mock_get_r.assert_has_calls([
                 call(),
-                call().set_metric("test-slug", 42, category=None, expire=300),
+                call().set_metric("test-slug", 42, category=None, expire=300, date=None),
             ])
 
     def test_metric(self):
@@ -75,7 +75,7 @@ class TestUtils(TestCase):
             utils.metric("test-slug")
             mock_get_r.assert_has_calls([
                 call(),
-                call().metric("test-slug", num=1, category=None, expire=None),
+                call().metric("test-slug", num=1, category=None, expire=None, date=None),
             ])
 
     def test_metric_with_category(self):
@@ -83,7 +83,7 @@ class TestUtils(TestCase):
             utils.metric("test-slug", category="Woo")
             mock_get_r.assert_has_calls([
                 call(),
-                call().metric("test-slug", num=1, category="Woo", expire=None),
+                call().metric("test-slug", num=1, category="Woo", expire=None, date=None),
             ])
 
     def test_metric_with_expiration(self):
@@ -91,7 +91,15 @@ class TestUtils(TestCase):
             utils.metric("test-slug", expire=300)
             mock_get_r.assert_has_calls([
                 call(),
-                call().metric("test-slug", num=1, category=None, expire=300),
+                call().metric("test-slug", num=1, category=None, expire=300, date=None),
+            ])
+
+    def test_metric_with_date(self):
+        with patch("redis_metrics.utils.get_r") as mock_get_r:
+            utils.metric("test-slug", expire=300)
+            mock_get_r.assert_has_calls([
+                call(),
+                call().metric("test-slug", num=1, category=None, expire=300, date=datetime(2000, 1, 2)),
             ])
 
     def test_gauge(self):

--- a/redis_metrics/tests/test_utils.py
+++ b/redis_metrics/tests/test_utils.py
@@ -96,10 +96,10 @@ class TestUtils(TestCase):
 
     def test_metric_with_date(self):
         with patch("redis_metrics.utils.get_r") as mock_get_r:
-            utils.metric("test-slug", expire=300)
+            utils.metric("test-slug", date=datetime(2000, 1, 2))
             mock_get_r.assert_has_calls([
                 call(),
-                call().metric("test-slug", num=1, category=None, expire=300, date=datetime(2000, 1, 2)),
+                call().metric("test-slug", num=1, category=None, expire=None, date=datetime(2000, 1, 2)),
             ])
 
     def test_gauge(self):

--- a/redis_metrics/utils.py
+++ b/redis_metrics/utils.py
@@ -14,14 +14,14 @@ def get_r():
     return _redis_model
 
 
-def set_metric(slug, value, category=None, expire=None):
+def set_metric(slug, value, category=None, expire=None, date=None):
     """Create/Increment a metric."""
-    get_r().set_metric(slug, value, category=category, expire=expire)
+    get_r().set_metric(slug, value, category=category, expire=expire, date=date)
 
 
-def metric(slug, num=1, category=None, expire=None):
+def metric(slug, num=1, category=None, expire=None, date=None):
     """Create/Increment a metric."""
-    get_r().metric(slug, num=num, category=category, expire=expire)
+    get_r().metric(slug, num=num, category=category, expire=expire, date=date)
 
 
 def gauge(slug, current_value):


### PR DESCRIPTION
This enables importing of historical data by adding an optional `date`
parameter to the `metric` and `set_metric` functions.

Closes #43.