### PR TITLE
added iso week support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,3 +14,4 @@ In no particular order:
 - Seamus Mac Conaonaigh `<https://github.com/smaccona>`_
 - Phoebe Bright `<https://github.com/phoebebright>`_
 - Stephan Pötschner `<https://github.com/stephanpoetschner>`_
+- Elias Laitinen `<https://github.com/eliasla>`_

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -56,6 +56,7 @@ which includes a number of options, all wich have the following defaults::
        'MIN_GRANULARITY': 'daily',
        'MAX_GRANULARITY': 'yearly',
        'MONDAY_FIRST_DAY_OF_WEEK': False,
+       'USE_ISO_WEEK_NUMBER': False,
     }
 
 Formerly, each of these were separate settings with a ``REDIS_METRICS_`` prefix.
@@ -74,6 +75,7 @@ Formerly, each of these were separate settings with a ``REDIS_METRICS_`` prefix.
 * ``MIN_GRANULARITY``: The minimum-time granularity for your metrics; default is 'daily'.
 * ``MAX_GRANULARITY``: The maximum-time granularity for your metrics; default is 'yearly'
 * ``MONDAY_FIRST_DAY_OF_WEEK``: Set to True if week should start on Monday; default is False
+* ``USE_ISO_WEEK_NUMBER``: Set to True to use ISO calendar weeks (see: https://docs.python.org/2/library/datetime.html#datetime.date.isocalendar)
 
 .. _`django-redis`: https://github.com/niwinz/django-redis
 .. _`django-redis-sentinel`: https://github.com/KabbageInc/django-redis-sentinel

--- a/redis_metrics/settings.py
+++ b/redis_metrics/settings.py
@@ -34,6 +34,7 @@ class AppSettings(object):
         'MIN_GRANULARITY': 'daily',
         'MAX_GRANULARITY': 'yearly',
         'MONDAY_FIRST_DAY_OF_WEEK': False,
+        'USE_ISO_WEEK_NUMBER': False,
     }
 
     # A mapping of our old settings names to the new name

--- a/redis_metrics/tests/test_templatetags.py
+++ b/redis_metrics/tests/test_templatetags.py
@@ -26,6 +26,7 @@ TEST_SETTINGS = {
     'MIN_GRANULARITY': 'seconds',
     'MAX_GRANULARITY': 'yearly',
     'MONDAY_FIRST_DAY_OF_WEEK': False,
+    'USE_ISO_WEEK_NUMBER': False,
 }
 
 

--- a/redis_metrics/tests/test_utils.py
+++ b/redis_metrics/tests/test_utils.py
@@ -22,6 +22,7 @@ TEST_SETTINGS = {
     'MIN_GRANULARITY': 'seconds',
     'MAX_GRANULARITY': 'yearly',
     'MONDAY_FIRST_DAY_OF_WEEK': False,
+    'USE_ISO_WEEK_NUMBER': False,
 }
 
 

--- a/redis_metrics/tests/test_views.py
+++ b/redis_metrics/tests/test_views.py
@@ -26,6 +26,7 @@ TEST_SETTINGS = {
     'MIN_GRANULARITY': 'seconds',
     'MAX_GRANULARITY': 'yearly',
     'MONDAY_FIRST_DAY_OF_WEEK': False,
+    'USE_ISO_WEEK_NUMBER': False,
 }
 
 


### PR DESCRIPTION
Added support for ISO week numbers weekly aggregates. In our use case, it was aggregating for weeks 53, 00 and 01 and it was not logical in user's perspective. Requirement was to use ISO week so it will use week 52 and 1.
Made a setting to use ISO week number, to maintain backwards compatibility.

- Added new setting USE_ISO_WEEK_NUMBER
- Added tests
- Updated documentation