### PR TITLE
Upgrades to make compatible with Django 2.2 - breaking changes in tests for Django <1.10

### DIFF
--- a/redis_metrics/tests/settings.py
+++ b/redis_metrics/tests/settings.py
@@ -33,19 +33,20 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-)
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
 
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
+    'django.contrib.messages',
     'django.contrib.sites',
     'django.contrib.staticfiles',
     'redis_metrics',

--- a/redis_metrics/tests/test_views.py
+++ b/redis_metrics/tests/test_views.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from mock import call, patch
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase, Client
 from django.test.utils import override_settings
 

--- a/redis_metrics/tests/urls.py
+++ b/redis_metrics/tests/urls.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^metrics/', include('redis_metrics.urls')),
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^metrics/', include('redis_metrics.urls')),
 ]

--- a/redis_metrics/urls.py
+++ b/redis_metrics/urls.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import (
     AggregateHistoryView, AggregateDetailView, AggregateFormView,
@@ -9,57 +9,57 @@ from .views import (
 
 
 urlpatterns = [
-    url(
+    re_path(
         r'^categorize/(?P<category_name>.*)/$',
         CategoryFormView.as_view(),
         name='redis_metrics_categorize'
     ),
-    url(
+    re_path(
         r'^categorize/$',
         CategoryFormView.as_view(),
         name='redis_metrics_categorize'
     ),
-    url(
+    re_path(
         r'^aggregate/category/(?P<category>.*)/$',
         AggregateDetailView.as_view(),
         name='redis_metric_aggregate_detail_by_category'
     ),
-    url(
+    re_path(
         r'^aggregate/(?P<slugs>.*)/(?P<granularity>.*)/$',
         AggregateHistoryView.as_view(),
         name='redis_metric_aggregate_history'
     ),
-    url(
+    re_path(
         r'^aggregate/(?P<slugs>.*)/$',
         AggregateDetailView.as_view(),
         name='redis_metric_aggregate_detail'
     ),
-    url(
+    re_path(
         r'^aggregate/$',
         AggregateFormView.as_view(),
         name='redis_metric_aggregate'
     ),
-    url(
+    re_path(
         r'^list/$',
         MetricsListView.as_view(),
         name='redis_metrics_list'
     ),
-    url(
+    re_path(
         r'^gauges/$',
         GaugesView.as_view(),
         name='redis_metrics_gauges'
     ),
-    url(
+    re_path(
         r'^(?P<slug>.*)/(?P<granularity>.*)/$',
         MetricHistoryView.as_view(),
         name='redis_metric_history'
     ),
-    url(
+    re_path(
         r'^(?P<slug>.*)/$',
         MetricDetailView.as_view(),
         name='redis_metric_detail'
     ),
-    url(
+    re_path(
         r'^$',
         DefaultView.as_view(),
         name='redis_metrics_default'

--- a/redis_metrics/views.py
+++ b/redis_metrics/views.py
@@ -10,7 +10,7 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 from django.contrib.auth.decorators import user_passes_test
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic.edit import FormView
 from django.views.generic import TemplateView
@@ -23,7 +23,7 @@ class ProtectedTemplateView(TemplateView):
     """Ensures that Users are authenticated and that they're staff users. This
     is used as a parent class for the rest of the views in this app."""
 
-    _logged_in_staff = lambda u: u.is_authenticated() and u.is_staff
+    _logged_in_staff = lambda u: u.is_authenticated and u.is_staff
 
     @method_decorator(user_passes_test(_logged_in_staff))
     def dispatch(self, *args, **kwargs):
@@ -34,7 +34,7 @@ class ProtectedFormView(FormView):
     """Ensures that Users are authenticated and that they're staff users. This
     is used as a parent class for the rest of the views in this app."""
 
-    _logged_in_staff = lambda u: u.is_authenticated() and u.is_staff
+    _logged_in_staff = lambda u: u.is_authenticated and u.is_staff
 
     @method_decorator(user_passes_test(_logged_in_staff))
     def dispatch(self, *args, **kwargs):


### PR DESCRIPTION
NOTE: The changes in redis_metrics/tests/settings.py are breaking changes for Django <1.10 and will cause tests to fail.
- converted MIDDLEWARE_CLASSES to >1.9 MIDDLEWARE
Session verification is enabled and mandatory in Django 1.10; SessionAuthenticationMiddleware not needed.
- django.contrib.messages app and MessageMiddleware required in order to use admin app.

- Removal of django.core.urlresolvers module in favor of django.urls
- Removal of django.conf.urls module in favor of django.urls
- urls() is now an alias for re_path(); renamed function calls for potential future proofing of urls() deprecation.
- user.is_authenticated is now an attribute, not a method.